### PR TITLE
Build and run Storybook, fix issues

### DIFF
--- a/src/ZoomLoop.WebApp/angular.json
+++ b/src/ZoomLoop.WebApp/angular.json
@@ -113,7 +113,12 @@
             "configDir": "projects/zoom-loop-components/.storybook",
             "browserTarget": "zoom-loop:build",
             "compodoc": false,
-            "port": 6006
+            "port": 6006,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "projects/zoom-loop-components/src/lib"
+              ]
+            }
           }
         },
         "build-storybook": {
@@ -122,7 +127,12 @@
             "configDir": "projects/zoom-loop-components/.storybook",
             "browserTarget": "zoom-loop:build",
             "compodoc": false,
-            "outputDir": "dist/storybook"
+            "outputDir": "dist/storybook",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "projects/zoom-loop-components/src/lib"
+              ]
+            }
           }
         }
       }

--- a/src/ZoomLoop.WebApp/projects/zoom-loop-components/src/lib/styles/_index.scss
+++ b/src/ZoomLoop.WebApp/projects/zoom-loop-components/src/lib/styles/_index.scss
@@ -1,5 +1,5 @@
 // Main entry point for zoom-loop-components styles
 // Import this file in your component SCSS to access design tokens and mixins
 
-@use './tokens' as *;
-@use './mixins' as *;
+@forward './tokens';
+@forward './mixins';

--- a/src/ZoomLoop.WebApp/projects/zoom-loop-components/src/lib/vehicles/vehicles.component.scss
+++ b/src/ZoomLoop.WebApp/projects/zoom-loop-components/src/lib/vehicles/vehicles.component.scss
@@ -1,8 +1,7 @@
 // Vehicles Component - BEM Methodology
 // Block: .vehicles
 
-@import '../styles/tokens';
-@import '../styles/mixins';
+@use '../styles/index' as *;
 
 .vehicles {
   display: flex;


### PR DESCRIPTION
- Change _index.scss to use @forward instead of @use to properly export tokens and mixins to consumers
- Update vehicles.component.scss to use modern @use syntax instead of deprecated @import
- Add stylePreprocessorOptions to Storybook builder configs in angular.json